### PR TITLE
[MySQL] Avoid condition when T is passed as an boolean option value

### DIFF
--- a/db-mysql/mysql-sql.lisp
+++ b/db-mysql/mysql-sql.lisp
@@ -159,7 +159,9 @@
                   (:boolean-ptr
                    (uffi:with-foreign-object (fo :byte)
                      (setf (uffi:deref-pointer fo :byte)
-                           (if (or (zerop value) (null value))
+                           (if (or (and (numberp value)
+                                        (zerop value))
+                                   (null value))
                                0
                                1))
                      (mysql-options mysql-ptr option-code fo)))))))))))


### PR DESCRIPTION
According to CLHS numberp signals a condition when its argument is not
a number. Additional check added.

Signed-off-by: Gleb Golubitsky sectoid@gnolltech.org
