### PR TITLE
Symbol construction fix.

### DIFF
--- a/sql/metaclasses.lisp
+++ b/sql/metaclasses.lisp
@@ -483,7 +483,8 @@ implementations."
 
          (macrolet
              ((safe-copy-value (name &optional default)
-                (let ((fn (intern (format nil "~A~A" 'view-class-slot- name ))))
+                (let ((fn (intern (concatenate 'string (symbol-name 'view-class-slot-)
+                                               (symbol-name name)))))
                   `(setf (slot-value esd ',name)
                     (or (when (slot-boundp dsd ',name)
                           (delistify-dsd (,fn dsd)))


### PR DESCRIPTION
Symbol is INTERN'ed in lower case when *print-case* is :downcase and
oodml.lisp fails to compile.