### PR TITLE
Some required changes for CLSQL to work under Lispworks 7.

### DIFF
--- a/sql/utils.lisp
+++ b/sql/utils.lisp
@@ -100,8 +100,8 @@
 
 #+lispworks
 (defvar +lw-has-without-preemption+
-  #+lispworks6 nil
-  #-lispworks6 t)
+  #-(or lispworks5 lispworks4) nil
+  #+(or lispworks5 lispworks4) t)
 #+lispworks
 (defvar +lw-global-lock+
   (unless +lw-has-without-preemption+


### PR DESCRIPTION
I've been using this for a while now. LW7 requires an extra option to
make sure slot values are not optimized when using MOP.

The second fix is minor, I don't remember how exactly it affects
CLSQL. But the feature check +:lispworks6 was used, whereas we really
need something like lispworks6+. Since that feature doesn't exist we
follow LW's guidelines and check for whether it's *not* lispworks4 or
5.